### PR TITLE
rewrite: extend existing built-in hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ a userscript that adds the following keyboard shortcuts to [Proton Calendar](htt
 
 - d / w / m - switches to day / week / month view
 - j / k - navigates back / forward
-- t - navigates to today
 
 ## installation
 

--- a/main.user.js
+++ b/main.user.js
@@ -1,50 +1,27 @@
 // ==UserScript==
 // @name        Proton Calendar keyboard shortcuts
 // @namespace   szamanr
-// @description adds keyboard shortcuts to proton calendar 
+// @description adds additional keyboard shortcuts to proton calendar
 // @match       https://calendar.proton.me/*
 // @grant       none
-// @version     0.1
+// @version     0.2
 // @author      szamanr
 // @supportURL  https://github.com/szamanr/proton-calendar-keyboard-shortcuts
 // @licence     MIT
 // ==/UserScript==
 
-const switchView = (type) => {
-  if (!["day", "month", "week"].includes(type)) return;
-
-  document.querySelector("[data-testid='calendar-view:view-options-dropdown']").click();
-  setTimeout(() => {
-    document.querySelector(`[data-testid='view-option-${type}']`).click();
-  }, 100);
-  setTimeout(() => {
-    document.querySelector("[data-testid='calendar-view:view-options-dropdown']").click();
-  }, 100);
-}
-
-const goToToday = () => {
-  document.querySelector("[data-testid='calendar-toolbar:today']").click();
-}
-
-const navigateBack = () => {
-  document.querySelector("[data-testid='calendar-toolbar:previous']").click();
-}
-
-const navigateForward = () => {
-  document.querySelector("[data-testid='calendar-toolbar:next']").click();
-}
+const sendKey = (key) => document.dispatchEvent(new KeyboardEvent('keydown', { key }));
 
 document.addEventListener('keydown', function(event) {
   if(["text", "textarea"].includes(event.target?.type)) return;
 
   const key = event.key.toLowerCase();
 
-  if (key === "d") switchView("day");
-  if (key === "m") switchView("month");
-  if (key === "w") switchView("week");
+  if (key === "d") sendKey("1")
+  if (key === "w") sendKey("2");
+  if (key === "m") sendKey("3");
 
-  if (key === "t") goToToday();
-  if (key === "j") navigateBack();
-  if (key === "k") navigateForward();
+  if (key === "j") sendKey("ArrowLeft");
+  if (key === "k") sendKey("ArrowRight");
 });
 


### PR DESCRIPTION
proton now added their own built-in shortcuts. this extension is still useful though, to be able to switch views using "d" / "w" / "m", and navigate back/forward using "j" and "k". 

- rewrite: extend existing built-in hotkeys
- update readme
